### PR TITLE
Added id to formArea

### DIFF
--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -24,7 +24,7 @@
 	<!-- Always add the csrf token to secure your form -->
 	{csrf}
 
-	{fbvFormArea}
+	{fbvFormArea id="controlPublicFilesSettingsCommon"}
 		{fbvFormSection label="plugins.generic.controlPublicFiles.setting.disableAllUploads" for="disableAllUploads" list=true}
 			{fbvElement
 				type="checkbox"


### PR DESCRIPTION
At the newest OJS installation (3.4.0-1) the plugin fails when you navigate to the settings page. The error originated because no id parameter was given to the formarea.

I've added the id parameter and the settings page works now